### PR TITLE
Resolve problema relativo ao acúmulo de mensagens e travamento do Lino

### DIFF
--- a/rasa/actions/calendar.py
+++ b/rasa/actions/calendar.py
@@ -1,5 +1,6 @@
 import os
 from rasa_core.actions.action import Action
+import requests
 
 # If you want to use your own bot to development add the bot token as
 # second parameters
@@ -14,13 +15,24 @@ class ActionCalendar(Action):
         dispatcher.utter_message('Calma aí, rapidinho!')
         dispatcher.utter_message('Vou buscar isso daí para você')
         crawlerRegister = 'https://webcrawler-matricula.lappis.rocks'
-        data = {}
-        data = {
-            'text': 'Aqui está o calendário de matrícula. '
-                    'Nele você pode adquirir informações de datas sobre: '
-                    'trancamento geral, parcial, período de matrícula, '
-                    'pré-matrícula, ajuste...',
-            'image': f'{crawlerRegister}/registration/downloadPdf'
+        try:
+            response = requests.get(
+                f'{crawlerRegister}/registration/downloadPdf',
+                timeout=3
+            )
+            data = {
+                'text': 'Aqui está o calendário de matrícula. '
+                        'Nele você pode adquirir informações de datas sobre: '
+                        'trancamento geral, parcial, período de matrícula, '
+                        'pré-matrícula, ajuste...',
+                'image': f'{crawlerRegister}/registration/downloadPdf'
             }
-        dispatcher.utter_response(data)
+            dispatcher.utter_response(data)
+        except Exception as exception:
+            dispatcher.utter_message(
+                "Tive um problema ao pegar o calendário acadêmico pra você... "
+                "Tenta mais tarde! Para que houve um problema no site onde "
+                "busco..."
+            )
+
         return []

--- a/rasa/actions/calendar.py
+++ b/rasa/actions/calendar.py
@@ -16,7 +16,7 @@ class ActionCalendar(Action):
         dispatcher.utter_message('Vou buscar isso daí para você')
         crawlerRegister = 'https://webcrawler-matricula.lappis.rocks'
         try:
-            response = requests.get(
+            requests.get(
                 f'{crawlerRegister}/registration/downloadPdf',
                 timeout=3
             )

--- a/rasa/actions/menu/daily_breakfast.py
+++ b/rasa/actions/menu/daily_breakfast.py
@@ -25,7 +25,8 @@ class ActionDailyBreakfast(Action):
         try:
             response = requests.get(
                 'http://webcrawler-ru.lappis.rocks/cardapio/{}'
-                .format(day)
+                .format(day),
+                timeout=3
             ).json()
         except Exception as exception:
             logging.info(exception)

--- a/rasa/actions/menu/daily_dinner.py
+++ b/rasa/actions/menu/daily_dinner.py
@@ -25,7 +25,8 @@ class ActionDailyDinner(Action):
         try:
             response = requests.get(
                 'http://webcrawler-ru.lappis.rocks/cardapio/{}'
-                .format(day)
+                .format(day),
+                timeout=3
             ).json()
         except Exception as exception:
             logging.info(exception)

--- a/rasa/actions/menu/daily_lunch.py
+++ b/rasa/actions/menu/daily_lunch.py
@@ -25,7 +25,8 @@ class ActionDailyLunch(Action):
         try:
             response = requests.get(
                 'http://webcrawler-ru.lappis.rocks/cardapio/{}'
-                .format(day)
+                .format(day),
+                timeout=3
             ).json()
         except Exception as exception:
             logging.info(exception)

--- a/rasa/actions/menu/daily_menu.py
+++ b/rasa/actions/menu/daily_menu.py
@@ -17,7 +17,8 @@ class ActionDailyMenu(Action):
         try:
             response = requests.get(
                 'http://webcrawler-ru.lappis.rocks/cardapio/{}'
-                .format(day)
+                .format(day),
+                timeout=3
             ).json()
         except Exception as exception:
             logging.info(exception)

--- a/rasa/actions/menu/week_menu.py
+++ b/rasa/actions/menu/week_menu.py
@@ -1,5 +1,6 @@
 import datetime
 from rasa_core.actions.action import Action
+import requests
 
 
 class ActionSendWeekMenu(Action):
@@ -13,7 +14,7 @@ class ActionSendWeekMenu(Action):
         img_timestamp = f'?time={timestamp}'
 
         try:
-            response = requests.get(
+            requests.get(
                 f'{crawler_url}{img_path}{img_timestamp}',
                 timeout=3
             )

--- a/rasa/actions/menu/week_menu.py
+++ b/rasa/actions/menu/week_menu.py
@@ -11,10 +11,24 @@ class ActionSendWeekMenu(Action):
         img_path = '/cardapio/pdf'
         timestamp = datetime.datetime.now().strftime("%d-%m-%Y")
         img_timestamp = f'?time={timestamp}'
-        data = {
-            'text': 'Tá aqui o cardápio da semana. '
-                    'Aprecie com moderação :)',
-            'image': f'{crawler_url}{img_path}{img_timestamp}'
-        }
-        dispatcher.utter_response(data)
+
+        try:
+            response = requests.get(
+                f'{crawler_url}{img_path}{img_timestamp}',
+                timeout=3
+            )
+
+            data = {
+                'text': 'Tá aqui o cardápio da semana. '
+                        'Aprecie com moderação :)',
+                'image': f'{crawler_url}{img_path}{img_timestamp}'
+            }
+            dispatcher.utter_response(data)
+        except Exception as exceptions:
+            dispatcher.utter_message(
+                "Não consegui pegar o cardápio da semana... "
+                "Acho que aconteceu um problema com o site do RU. "
+                "Tenta depois! O problema vai resolver em algum momento kk"
+            )
+
         return []


### PR DESCRIPTION
## Descrição 

Foi feito um tratamento prematuro em relação ao problema grave que ocorria ao solicitar qualquer informação que fazia o uso de _links_ externos, ocorrendo o travamento do bot e o acúmulo de mensagens em sua _queue_.  O problema em si que ocorria era que o bot realizava a tentativa de requisição durante um tempo indeterminado, ocorrendo seu travamento e ocasionando o acúmulo de mensagens. Logo, para a solução deste problema, foi colocado um **timeout** de três segundos para ele interromper esse tratamento ocasionado pela tentativa de requisição.

## Resolve (Issues)

#8 

## Notas pessoais sobre o PR

Tal problema poderá ocorrer com a implementação de outras _features_ de funcionamento semelhante. Porém, é necessário frisar que tal solução não é definitiva. Devem existir outros problemas que podem ocasionar 