### PR TITLE
Melhorar redundância em intents

### DIFF
--- a/rasa/data/intents/calendar.md
+++ b/rasa/data/intents/calendar.md
@@ -32,7 +32,6 @@
 - manda o [calendario de matrícula](calendar)
 - cade o [calendario de matrícula](calendar)
 - passa o [calendario de matrícula](calendar)
-- Lino, [calendario de matrícula](calendar)
 <!-- trancamento geral -->
 - Trancamento de [matrícula](calendar)
 - [trancamento](calendar)

--- a/rasa/data/intents/compliments.md
+++ b/rasa/data/intents/compliments.md
@@ -33,7 +33,6 @@
 - lindo
 - lindao
 - maravilhoso
-- top
 - gato
 - gado
 - topzera

--- a/rasa/data/intents/documents.md
+++ b/rasa/data/intents/documents.md
@@ -40,14 +40,11 @@
 - meia entrada
 
 ## intent:asks_about_schedule
-- [grade horaria](documents)
 - me diz como arranjo minha grade horária
 - eae bot, grade horária
 - me manda ai como pegar meus horários
 - [grade horaria](documents)
 - [grade horária](documents)
-- [Grade horaria](documents)
-- [Grade horária](documents)
 - me diz ai, como faço pra pegar a [grade horaria](documents)
 - eae bot, [grade horaria](documents)
 - [grade horaria](documents), pfvr
@@ -56,7 +53,6 @@
 - preciso da [grade horaria](documents)
 - preciso da [grade horaria](documents), como faz
 - preciso da [grade horaria](documents), como arranjo?
-- meu plano de saúde tá acabando e preciso da [grade horária](documents) desse semestre. como procedo?
 - [grade horária](documents)??
 - me diz ai, como faço pra pegar a [grade horária](documents)
 - eae bot, [grade horária](documents)
@@ -67,19 +63,11 @@
 - preciso da [grade horária](documents), como faz
 - preciso da [grade horária](documents), como arranjo?
 - meu plano de saúde tá acabando e preciso da [grade horária](documents) desse semestre. como procedo?
-- [grade horária](documents)??
 
 ## intent:asks_register_proof
-- Como pegar o [comprovante de matrícula](documents)?
 - como pegar o [comprovante de matrícula](documents)?
-- [Comprovante de matrícula](documents)
 - [comprovante de matrícula](documents)
-- [Comprovante de matricula](documents)
 - [comprovante de matricula](documents)
-- [Comprovante de Matrícula](documents)
-- [comprovante de Matrícula](documents)
-- [Comprovante de Matricula](documents)
-- [comprovante de Matricula](documents)
 - Eae, como pego que pego o [comprovante de matrícula](documents)?
 - oi Lino, como que faço pra retirar o [comprovante de matricula](documents)?
 - fala bixo, me manda ae como arranja o [comprovante de matricula](documents)
@@ -87,19 +75,11 @@
 - eaeee, [comprovante de matrícula](documents)
 - [comprov de matr](documents)
 - [comprovante de matricual](documents), cara
-- [comprovante de matricula](documents), cara
 - bot, [comprovante de matricula](documents)
 
 ## intent:asks_tutoring_proof
-- Como pegar o [declaração de monitoria](documents)?
-- como pegar o [Declaração de monitoria](documents)?
-- [Declaracao de monitoria](documents)
+- como pegar o [declaração de monitoria](documents)?
 - [declaracao de monitoria](documents)
-- [declaracao de Monitoria](documents)
-- [declaração de Monitoria](documents)
-- [Declaração de monitoria](documents)
-- [Declaração de Monitoria](documents)
-- [Declaracao de Monitoria](documents)
 - [declaração de monitoria](documents)
 - Eae, como pego que pego o [declaração de monitoria](documents)?
 - oi Lino, como que faço pra retirar o [declaracao de monitoria](documents)?
@@ -114,14 +94,9 @@
 ## intent:asks_course_period_proof
 - Como pegar o [declaração de período de curso](documents)?
 - como pegar o [declaração de periodo de curso](documents)?
-- [Declaracao de periodo de curso](documents)
+- [declaracao de periodo de curso](documents)
 - [declaracao de monitoria](documents)
-- [declaracao de Periodo de Curso](documents)
-- [Declaração de Período de Curso](documents)
-- [Declaracao de Periodo de Curso](documents)
-- [declaração de Período de Curso](documents)
-- [Declaração de periodo de Curso](documents)
-- [Declaração de Período de curso](documents)
+- [Declaração de periodo de curso](documents)
 - Eae, como pego que pego o [Declaração de período de curso](documents)?
 - oi Lino, como que faço pra retirar o [declaracao de período de curso](documents)?
 - fala bixo, me manda ae como arranja o [declaração de período de curso](documents)
@@ -135,11 +110,6 @@
 ## intent:asks_school_history_proof
 - Como pegar o [histórico escolar](documents)?
 - como pegar o [historico escolar](documents)?
-- [Histórico Escolar](documents)
-- [Histórico escolar](documents)
-- [Historico escolar](documents)
-- [historico Escolar](documents)
-- [histórico Escolar](documents)
 - [histórico escolar](documents)
 - [historico escolar](documents)
 - Eae, como pego que pego o [histórico escolar](documents)?
@@ -148,6 +118,5 @@
 - opa mano, me diz sobre o [hist escolar](documents)
 - eaeee, [historcio escolar](documents)
 - [hist escl](documents)
-- [histórico escolar](documents), cara
 - [histórico escolar](documents), cara
 - bot, [histórico escolar](documents)

--- a/rasa/data/intents/general.md
+++ b/rasa/data/intents/general.md
@@ -22,7 +22,6 @@
 - [/help](command)
 
 ## intent:greet
-- [Oi](oi)
 - [oi](oi)
 - [oi](oi) amigo
 - [Olá](oi)

--- a/rasa/data/intents/menu.md
+++ b/rasa/data/intents/menu.md
@@ -40,8 +40,7 @@
 - então, o que tem pra comer [hoje](period)?
 
 ## intent: asks_weekly_menu
-- Me fala o cardápio de [semana](period)
-- Me fala o cardápio de [semana](period)
+- Me fala o cardápio da [semana](period)
 - O que tem pra comer [semana](period)
 - Qual é o cardápio de [semana](period)
 - Me passa o cardápio de [semana](period)
@@ -89,7 +88,6 @@
 ## intent: asks_lunch_menu
 <!-- almoço -->
 - Me fala o cardápio do [almoço](meal)
-- Me fala o cardápio do [almoço](meal)
 - O que tem pra comer no [almoço](meal)
 - Qual é o cardápio do [almoço](meal)
 - Me passa o cardápio do [almoço](meal)
@@ -113,7 +111,6 @@
 ## intent: asks_breakfast_menu
 <!-- café da manhã -->
 - Me fala o cardápio do [café da manhã](meal)
-- Me fala o cardápio do [café da manhã](meal)
 - O que tem pra comer no [café da manhã](meal)
 - Qual é o cardápio do [café da manhã](meal)
 - Me passa o cardápio do [café da manhã](meal)
@@ -133,7 +130,6 @@
 - o que vai ser servido no [café da manhã](meal)?
 - então, o que tem pra comer no [café da manhã](meal)?
 <!-- café -->
-- Me fala o cardápio do [café](meal)
 - Me fala o cardápio do [café](meal)
 - O que tem pra comer no [café](meal)
 - Qual é o cardápio do [café](meal)
@@ -155,7 +151,6 @@
 - então, o que tem pra comer no [café](meal)?
 <!-- cafe da manha -->
 - Me fala o cardápio do [cafe da manha](meal)
-- Me fala o cardápio do [cafe da manha](meal)
 - O que tem pra comer no [cafe da manha](meal)
 - Qual é o cardápio do [cafe da manha](meal)
 - Me passa o cardápio do [cafe da manha](meal)
@@ -176,7 +171,6 @@
 - então, o que tem pra comer no [cafe da manha](meal)?
 <!-- cafe -->
 - Me fala o cardápio do [cafe](meal)
-- Me fala o cardápio do [cafe](meal)
 - O que tem pra comer no [cafe](meal)
 - Qual é o cardápio do [cafe](meal)
 - Me passa o cardápio do [cafe](meal)
@@ -196,7 +190,6 @@
 - o que vai ser servido no [cafe](meal)?
 - então, o que tem pra comer no [cafe](meal)?
 <!-- desjejum -->
-- Me fala o cardápio do [desjejum](meal)
 - Me fala o cardápio do [desjejum](meal)
 - O que tem pra comer no [desjejum](meal)
 - Qual é o cardápio do [desjejum](meal)

--- a/rasa/data/intents/notifications.md
+++ b/rasa/data/intents/notifications.md
@@ -55,7 +55,6 @@
 - Me cadastra pra receber alerta da comunidade
 - Quero receber sobre alerta da comunidade
 - notificações alerta da comunidade
-- alerta da comunidade
 - alerta da comunidade pretty please
 - quero me cadastrar pra lista de notificações do alerta da comunidade
 - me inscreve pra receber o alerta da comunidade por favor
@@ -97,13 +96,13 @@
 - [não](option) quero receber mais [notificação](notification)
 - [nao](option) quero receber mais [notificaçao](notification)
 - [não](option) quero receber mais [notificações](notification)
-- [não](option) quero receber mais [notificações](notification)
+- [não](option) quero receber mais [notificaçoes](notification)
 - [não](option) quero [notificação](notification)
 - [não](option) quero [notificações](notification)
 - [sem](option) [notificação](notification)
 - [sem](option) [notificaçao](notification)
 - [sem](option) [notificações](notification)
-- [sem](option) [notificações](notification)
+- [sem](option) [notificaçoes](notification)
 - [quero tirar](option) as [notificações](notification)
 - [quero tirar](option) as [notificaçoes](notification)
 - [quero tirar](option) a [notificação](notification)

--- a/rasa/data/intents/random.md
+++ b/rasa/data/intents/random.md
@@ -237,7 +237,6 @@
 ## intent:sons
 - Você tem [filhos](sons)?
 - [filhos](sons)?
-- Você tem [filhos](sons)?
 - [filho](sons)
 - [filha](sons)
 - [filhas](sons)?


### PR DESCRIPTION
## Descrição 

Remove todas intents duplicadas com o objetivo apenas de alterar a acurácia a partir da identificação de _lowercases_ e _uppercases_.

Comando para testar linhas duplicadas dentro da pasta de intents:
`for i in *.md; do echo $i && sort $i | uniq -idc; done`

Closes #13 